### PR TITLE
fixes and automation

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ Change these values in `init.sh`.
 
 `DOCKER_USER=your_dockerhub_user`
 
+NOTE: ensure you are logged into dockerhub or you may get a confusing "permission denied" error during `docker push`
+
 Make the necessary changes in `Configmaps` according to your setup.
 
 **Deploy Prometheus and Grafana**

--- a/README.md
+++ b/README.md
@@ -41,8 +41,6 @@ Change these values in `init.sh`.
 
 `DOCKER_USER=your_dockerhub_user`
 
-NOTE: ensure you are logged into dockerhub or you may get a confusing "permission denied" error during `docker push`
-
 Make the necessary changes in `Configmaps` according to your setup.
 
 **Deploy Prometheus and Grafana**

--- a/definitions/alertmanager_proxy.sh
+++ b/definitions/alertmanager_proxy.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+POD=$(kubectl get pods --namespace=monitoring | grep alertmanager| cut -d ' ' -f 1)
+kubectl port-forward $POD --namespace=monitoring 9093:9093

--- a/definitions/grafana_proxy.sh
+++ b/definitions/grafana_proxy.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+POD=$(kubectl get pods --namespace=monitoring | grep grafana| cut -d ' ' -f 1)
+kubectl port-forward $POD --namespace=monitoring 3000:3000

--- a/definitions/init.sh
+++ b/definitions/init.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-GRAFANA_VERSION=4.1.1
-PROMETHEUS_VERSION=v1.5.0
-DOCKER_USER=camil
+GRAFANA_DEFAULT_VERSION=4.2.0
+PROMETHEUS_DEFAULT_VERSION=v1.6.3
+DOCKER_USER_DEFAULT=$(whoami)
 RED='\033[0;31m'
 GREEN='\033[0;32m'
 ORANGE='\033[0;33m'
@@ -15,8 +15,23 @@ tput sgr0
 #create a separate namespace for monitoring
 kubectl create namespace monitoring
 
+#Ask for grafana version or apply default
 echo
+read -p "Enter Grafana version [$GRAFANA_DEFAULT_VERSION]: " GRAFANA_VERSION
+GRAFANA_VERSION=${GRAFANA_VERSION:-$GRAFANA_DEFAULT_VERSION}
+
+#Ask for prometheus version or apply default
+echo
+read -p "Enter Prometheus version [$PROMETHEUS_DEFAULT_VERSION]: " PROMETHEUS_VERSION
+PROMETHEUS_VERSION=${PROMETHEUS_VERSION:-$PROMETHEUS_DEFAULT_VERSION}
+
+#Ask for dockerhub user or apply default of the current logged-in username
+echo
+read -p "Enter Dockerhub username [$DOCKER_USER_DEFAULT]: " DOCKER_USER
+DOCKER_USER=${DOCKER_USER:-$DOCKER_USER_DEFAULT}
+
 #Set username and password for basic-auth
+echo
 echo -e "${BLUE}Please set the username and password for basic-auth and [ENTER]:"
 tput sgr0
 
@@ -66,49 +81,63 @@ echo -e "${BLUE}SMTP password set."
 tput sgr0
 echo
 
-#AWS credentials for EC2 monitoring
-echo -e "${ORANGE}Insert your AWS Access Key and press [ENTER]:"
+#try to figure out AWS credentials for EC2 monitoring, if not...ask.
+echo -e "${BLUE}Detecting AWS access keys."
 tput sgr0
-
-#aws access key
-prompt="AWS Access Key:"
-tput sgr0
-while IFS= read -p "$prompt" -r -s -n 1 char
-do
-    if [[ $char == $'\0' ]]
-    then
-        break
-    fi
-    prompt='*'
-    aws_access_key+="$char"
-done
 echo
+if [ ! -z $AWS_ACCESS_KEY_ID ] && [ ! -z $AWS_SECRET_ACCESS_KEY ]; then
+  aws_access_key=$AWS_ACCESS_KEY_ID
+  aws_access_password=$AWS_SECRET_ACCESS_KEY
+  echo -e "${ORANGE}AWS_ACCESS_KEY_ID found, using $aws_access_key."
+  tput sgr0
+  echo
+elif [ ! -z $AWS_ACCESS_KEY ] && [ ! -z $AWS_SECRET_KEY ]; then
+  aws_access_key=$AWS_ACCESS_KEY
+  aws_access_password=$AWS_SECRET_KEY
+  echo -e "${ORANGE}AWS_ACCESS_KEY found, using $aws_access_key."
+  tput sgr0
+  echo
+else
+  echo -e "${RED}Unable to determine AWS credetials from environment variables."
+  echo -e "${ORANGE}Insert your AWS Access Key ID and press [ENTER]:"
+  tput sgr0
+
+  #aws access key
+  prompt="AWS Access Key ID:"
+  tput sgr0
+  while IFS= read -p "$prompt" -r -s -n 1 char
+  do
+      if [[ $char == $'\0' ]]
+      then
+          break
+      fi
+      prompt='*'
+      aws_access_key+="$char"
+  done
+  echo
+
+  #aws secret access key
+  echo -e "${ORANGE}Insert your AWS Secret Access Key and press [ENTER]:"
+  tput sgr0
+
+  prompt="AWS Secret Access Key:"
+  tput sgr0
+  while IFS= read -p "$prompt" -r -s -n 1 char
+  do
+      if [[ $char == $'\0' ]]
+      then
+          break
+      fi
+      prompt='*'
+      aws_access_password+="$char"
+  done
+  echo
+fi
+
+#sed in the AWS credentials. this looks odd because aws secret access keys can have '/' as a valid character
+#so we use ',' as a delimiter for sed, since that won't appear in the secret key
 sed -i -e 's/aws_access_key/'"$aws_access_key"'/g' k8s/prometheus/01-prometheus.configmap.yaml
-echo -e "${ORANGE}AWS Access Key set."
-echo
-tput sgr0
-
-#aws access password
-echo -e "${ORANGE}Insert your AWS Access Password and press [ENTER]:"
-tput sgr0
-
-prompt="AWS Access Password:"
-tput sgr0
-while IFS= read -p "$prompt" -r -s -n 1 char
-do
-    if [[ $char == $'\0' ]]
-    then
-        break
-    fi
-    prompt='*'
-    aws_access_password+="$char"
-done
-echo
-sed -i -e 's/aws_access_password/'"$aws_access_password"'/g' k8s/prometheus/01-prometheus.configmap.yaml
-echo -e "${ORANGE}AWS Access Password set."
-tput sgr0
-
-echo
+sed -i -e 's,aws_access_password,'"$aws_access_password"',g' k8s/prometheus/01-prometheus.configmap.yaml
 
 #slack channel
 echo -e "${PURPLE}Insert your slack channel name where you wish to receive alerts and press [ENTER]:"

--- a/definitions/init.sh
+++ b/definitions/init.sh
@@ -2,7 +2,7 @@
 
 GRAFANA_DEFAULT_VERSION=4.2.0
 PROMETHEUS_DEFAULT_VERSION=v1.6.3
-DOCKER_USER_DEFAULT=$(whoami)
+DOCKER_USER_DEFAULT=$(docker info|grep Username:|awk '{print $2}')
 RED='\033[0;31m'
 GREEN='\033[0;32m'
 ORANGE='\033[0;33m'
@@ -184,6 +184,19 @@ echo
 echo -e "${BLUE}Pushing grafana docker image to DockerHub"
 tput sgr0
 docker push $DOCKER_USER/grafana:$GRAFANA_VERSION
+#upon failure, run docker login
+if [ $? -eq 1 ];then
+  echo -e "${RED}docker push failed! perhaps you need to login \"${DOCKER_USER}\" to dockerhub?"
+  tput sgr0
+  docker login -u $DOCKER_USER
+  #try again
+  docker push $DOCKER_USER/grafana:$GRAFANA_VERSION
+  if [ $? -eq 1 ];then
+    echo -e "${RED}docker push failed a second time! exiting."
+    ./cleanup.sh
+    exit 1
+  fi
+fi
 
 echo
 

--- a/definitions/k8s/prometheus/02-prometheus.svc.statefulset.yaml
+++ b/definitions/k8s/prometheus/02-prometheus.svc.statefulset.yaml
@@ -17,7 +17,7 @@ spec:
     port: 9090
     targetPort: 9090
 ---
-apiVersion: apps/v1alpha1
+apiVersion: apps/v1beta1
 kind: StatefulSet
 metadata:
   name: prometheus

--- a/definitions/prometheus_proxy.sh
+++ b/definitions/prometheus_proxy.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+POD=$(kubectl get pods --namespace=monitoring | grep prometheus| cut -d ' ' -f 1)
+kubectl port-forward $POD --namespace=monitoring 9090:9090


### PR DESCRIPTION
* improved interaction with dockerhub to try and avoid nondescript error messages
* made Grafana and Prometheus versions overridable defaults
* updated versions to latest (Grafana 4.2.0 and Prometheus 1.6.3)
* added autodetection of dockerhub username and AWS credentials
* updated nomenclature of AWS credentials to match AWSCLI config standards
* fixed a bug in the sed for AWS secret access key (see comment on line 137 for further explanation)
* added proxy scripts for grafana, prometheus, and alertmanager web interfaces for post-install flexibility