### PR TITLE
Fix in storage type substitution on AWS case

### DIFF
--- a/manifests/prometheus/prometheus-k8s.yaml
+++ b/manifests/prometheus/prometheus-k8s.yaml
@@ -4,7 +4,7 @@ metadata:
   name: ssd
 provisioner: STORAGE_CLASS_PROVISIONER
 parameters:
-  type: pd-standard
+  type: STORAGE_CLASS_TYPE
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: Prometheus


### PR DESCRIPTION
There's an error on the storage type sed for AWS, it expects to found the STORAGE_CLASS_TYPE on storage 'type:' definition but the prometheus-kubernetes/manifests/prometheus/prometheus-k8s.yaml has 'pd-standard' on the type.