### PR TITLE
Fix the check for BSD/GNU base64

### DIFF
--- a/scripts/generate-alertmanager-config-secret.sh
+++ b/scripts/generate-alertmanager-config-secret.sh
@@ -1,9 +1,11 @@
 #!/bin/bash
-os=$(uname)
-if [[ $os == "Darwin" ]]; then
-  b64="base64"
+
+# Check whether the base64 binary is GNU or BSD
+echo "" | base64 --wrap=0 > /dev/null 2>&1
+if [ "$?" -eq 0 ]; then
+    b64="base64 --wrap=0"
 else
-  b64="base64 --wrap=0"
+    b64="base64"
 fi
 
 cat <<-EOF >  ../manifests/alertmanager/alertmanager.cm.yaml


### PR DESCRIPTION
There are times when Mac has the gnu version of base64 installed,
which breaks the script. This is to ensure that the correct switch
is used on the appropriate `base64` binary.