### PR TITLE
fix: update grafana dashboard migration comments to ensure the possiblity of more dashboards

### DIFF
--- a/scripts/wrap-dashboard.sh
+++ b/scripts/wrap-dashboard.sh
@@ -11,9 +11,9 @@
 #  * Drop dashboard specification in assets folder:
 #      mv Nodes-1488465802729.json assets/grafana/node-dashboard.json
 #  * Regenerate Grafana configmap:
-#      ./hack/scripts/generate-manifests.sh
+#      ./scripts/generate-manifests.sh
 #  * Apply new configmap:
-#      kubectl -n monitoring apply -f manifests/grafana/grafana-cm.yaml
+#      kubectl -n monitoring apply -f manifests/grafana/grafana-dashboards-configmap.yaml
 
 if [ "$#" -ne 1 ]; then
     echo "Usage: $0 path-to-dashboard.json"

--- a/scripts/wrap-dashboard.sh
+++ b/scripts/wrap-dashboard.sh
@@ -13,7 +13,7 @@
 #  * Regenerate Grafana configmap:
 #      ./scripts/generate-manifests.sh
 #  * Apply new configmap:
-#      kubectl -n monitoring apply -f manifests/grafana/grafana-dashboards-configmap.yaml
+#      kubectl -n monitoring replace -f manifests/grafana/grafana-dashboards-configmap.yaml
 
 if [ "$#" -ne 1 ]; then
     echo "Usage: $0 path-to-dashboard.json"

--- a/scripts/wrap-dashboard.sh
+++ b/scripts/wrap-dashboard.sh
@@ -13,7 +13,7 @@
 #  * Regenerate Grafana configmap:
 #      ./scripts/generate-manifests.sh
 #  * Apply new configmap:
-#      kubectl -n monitoring replace -f manifests/grafana/grafana-dashboards-configmap.yaml
+#      kubectl -n monitoring replace -f manifests/grafana/grafana-dashboards.cm.yaml
 
 if [ "$#" -ne 1 ]; then
     echo "Usage: $0 path-to-dashboard.json"


### PR DESCRIPTION
When adding more and more dashboards to Grafana, I encountered this issue: https://github.com/coreos/prometheus-operator/issues/535 which limits the size of the config map. The old config map is stored in an annotation, and annotation might have a max size of 256kb. Using replace instead of apply just replaces the configmap. The flip side of this is that we don't have version control. But devs should have the dashboards in the assets-folder anyway.