### PR TITLE
Don't assume to override the default storage class

### DIFF
--- a/manifests/prometheus/prometheus-k8s.yaml
+++ b/manifests/prometheus/prometheus-k8s.yaml
@@ -2,8 +2,6 @@ apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   name: ssd
-  annotations:
-    storageclass.beta.kubernetes.io/is-default-class: "true"
 provisioner: STORAGE_CLASS_PROVISIONER
 parameters:
   type: STORAGE_CLASS_TYPE


### PR DESCRIPTION
In most environments, they come with default storage classes. We should not assume to steal that away from other tools. 

We already explicitly use `sdd` as a storage class.

GKE already has a default storage class and I assume a bunch of other installers for cloud deployments (kops for aws) also do.  

Do we need this?