### PR TITLE
fix sed bug in deploy.sh to modify prometheus-k8s.yaml

### DIFF
--- a/deploy
+++ b/deploy
@@ -122,7 +122,7 @@ do
             ;;
         "Custom")
             echo "Deploying on custom providers without persistence"
-            sed -i -e '1,8d;32,45d' manifests/prometheus/prometheus-k8s.yaml;
+            sed -i -e '1,8d;32,49d' manifests/prometheus/prometheus-k8s.yaml;
             rm -rf manifests/grafana/grafana.pvc.yaml
             sed -i -e '31,34d;77,79d' manifests/grafana/grafana.de.yaml;
             break


### PR DESCRIPTION
When cloud provider is 4Custom like deploy in minikube, manifests/prometheus/prometheus-k8s.yaml needs to be modified,
but line bug is in sed command ,
change
`sed -i -e '1,8d;32,45d' manifests/prometheus/prometheus-k8s.yaml`
to 
`sed -i -e '1,8d;32,49d' manifests/prometheus/prometheus-k8s.yaml`