### PR TITLE
chore: add missing storage class type for grafana

### DIFF
--- a/deploy
+++ b/deploy
@@ -102,6 +102,7 @@ do
             fi
             sed -i -e 's,STORAGE_CLASS_PROVISIONER,'"$STORAGE_CLASS_PROVISIONER"',g' manifests/prometheus/prometheus-k8s.yaml;
             sed -i -e 's,STORAGE_CLASS_TYPE,'"$STORAGE_CLASS_TYPE"',g' manifests/prometheus/prometheus-k8s.yaml;
+            sed -i -e 's,STORAGE_CLASS_TYPE,'"$STORAGE_CLASS_TYPE"',g' manifests/grafana/grafana.pvc.yaml;
             break
             ;;
         "Azure")


### PR DESCRIPTION
The storage class type for the grafana pvc is not set in the deploy script for google cloud