### PR TITLE
chore: increase the resource limit and request for kube-state-metrics

### DIFF
--- a/manifests/kube-state-metrics/kube-state-metrics.de.yaml
+++ b/manifests/kube-state-metrics/kube-state-metrics.de.yaml
@@ -22,6 +22,13 @@ spec:
           containerPort: 8080
         - name: telemetry
           containerPort: 8081
+        resources:
+          limits:
+            cpu: 200m
+            memory: 300Mi
+          requests:
+            cpu: 100m
+            memory: 200Mi
         readinessProbe:
           httpGet:
             path: /healthz
@@ -32,11 +39,11 @@ spec:
         image: k8s.gcr.io/addon-resizer:1.7
         resources:
           limits:
-            cpu: 200m
-            memory: 300Mi
+            cpu: 100m
+            memory: 30Mi
           requests:
             cpu: 100m
-            memory: 200Mi
+            memory: 30Mi
         env:
           - name: MY_POD_NAME
             valueFrom:

--- a/manifests/kube-state-metrics/kube-state-metrics.de.yaml
+++ b/manifests/kube-state-metrics/kube-state-metrics.de.yaml
@@ -32,11 +32,11 @@ spec:
         image: k8s.gcr.io/addon-resizer:1.7
         resources:
           limits:
-            cpu: 100m
-            memory: 30Mi
+            cpu: 200m
+            memory: 300Mi
           requests:
             cpu: 100m
-            memory: 30Mi
+            memory: 200Mi
         env:
           - name: MY_POD_NAME
             valueFrom:


### PR DESCRIPTION
Increasing the resource limit and request for kube-state-metrics because it explicitly requires 200mb which might be a bit high for the default memory limit in the cluster